### PR TITLE
alt-x should show command bar

### DIFF
--- a/emacs.keymap
+++ b/emacs.keymap
@@ -79,4 +79,5 @@
                          "alt-g g" [:goto-line]
                          "ctrl-q tab" [(:emacs.keymap-cmd "Tab" "emacs-Ctrl-Q")]
                          "alt-x" [:show-commandbar-transient]
+                         "ctrl-x ctrl-e" [:eval-editor-form]
                          }}}


### PR DESCRIPTION
The command bar is the equivalent of Emacs' execute-extended-command, so I added a keybinding to M-x (alt-x).

I'm happy to sign a CA, if you'd kindly point me to it. Cheers!
