### PR TITLE
Add common "select all" command to keymap.

### DIFF
--- a/emacs.keymap
+++ b/emacs.keymap
@@ -89,4 +89,5 @@
                          "alt-g alt-g" [:goto-line]
                          "ctrl-s" [:find.fill-selection :find.show]
                          "ctrl-q tab" [(:emacs.keymap-cmd "Tab" "emacs-Ctrl-Q")]
+                         "ctrl-x h" [:editor.select-all]
                          }}}


### PR DESCRIPTION
I noticed this mode was missing this shortcut I use quite a bit in Emacs, and for some reason "pmeta-a" was disabled for highlighting all of the text in a "buffer".
