### PR TITLE
user.behaviors format changed for 0.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A thin wrapper around CodeMirror's Emacs mode that integrates it into Light Tabl
 
 Add the following to your `user.behaviors` (Ctrl-Space -> Settings: User behaviors) in the `:editor` section
 
-    (:lt.plugins.emacs/activate-emacs)
+    [:lt.plugins.emacs/activate-emacs]
 
 ### License
 


### PR DESCRIPTION
Lighttable version 0.7.x uses a different format for user.behaviours and therefore behaviours need to be either a vector or a map.  I've updated the README.md file to show that the user.behavior entry should be added as a vector (rather than a list).